### PR TITLE
sweep2wake - finally :D

### DIFF
--- a/drivers/input/misc/gpio_event.c
+++ b/drivers/input/misc/gpio_event.c
@@ -20,6 +20,9 @@
 #include <linux/hrtimer.h>
 #include <linux/platform_device.h>
 #include <linux/slab.h>
+#ifdef CONFIG_TOUCHSCREEN_ATMEL_SWEEP2WAKE
+#include <linux/atmel_qt602240.h>
+#endif
 
 struct gpio_event {
 	struct gpio_event_input_devs *input_devs;
@@ -166,6 +169,12 @@ static int gpio_event_probe(struct platform_device *pdev)
 					event_info->name : event_info->names[i];
 		input_dev->event = gpio_input_event;
 		ip->input_devs->dev[i] = input_dev;
+#ifdef CONFIG_TOUCHSCREEN_ATMEL_SWEEP2WAKE
+		if (!strcmp(input_dev->name, "shooteru-keypad")) {
+			sweep2wake_setdev(input_dev);
+			printk(KERN_INFO "[sweep2wake]: set keypad device as %s\n", input_dev->name);
+		}
+#endif
 	}
 	ip->input_devs->count = dev_count;
 	ip->info = event_info;

--- a/drivers/input/touchscreen/Kconfig
+++ b/drivers/input/touchscreen/Kconfig
@@ -41,6 +41,41 @@ config TOUCHSCREEN_ATMEL
 	help
 	  This enables support for Atmel over I2C based touchscreens.
 
+config TOUCHSCREEN_ATMEL_SWEEP2WAKE
+	bool "Sweep2Wake for Atmel based touchscreens"
+	depends on TOUCHSCREEN_ATMEL
+	default n
+	help
+	  This will enable sweep2wake for ATMEL touchscreen
+
+choice
+	prompt "Default ATMEL SWEEP2WAKE setting"
+	help
+		This option sets the ATMEL sweep2wake startup settings.
+		If in doubt, select 'disabled'.
+
+config TOUCHSCREEN_ATMEL_SWEEP2WAKE_DISABLED
+	bool "disabled"
+	depends on TOUCHSCREEN_ATMEL_SWEEP2WAKE
+	help
+		Build ATMEL sweep2wake into kernel, but leave disabled by
+		default.
+
+config TOUCHSCREEN_ATMEL_SWEEP2WAKE_ENABLED
+	bool "enabled"
+	depends on TOUCHSCREEN_ATMEL_SWEEP2WAKE
+	help
+		Build ATMEL sweep2wake into kernel, and enable by default.
+
+config TOUCHSCREEN_ATMEL_SWEEP2WAKE_ENABLED_WITH_BACKLIGHT
+	bool "enabled_with_backlight"
+	depends on TOUCHSCREEN_ATMEL_SWEEP2WAKE
+	help
+		Build ATMEL sweep2wake into kernel, and enable by default
+		with backlight.
+
+endchoice
+
 config TOUCHSCREEN_NTRIG
 	tristate "N-trig spi touchscreen"
 	depends on SPI_TOUCHSCREEN_NTRIG

--- a/drivers/input/touchscreen/atmel.c
+++ b/drivers/input/touchscreen/atmel.c
@@ -36,6 +36,10 @@
 #include <linux/stat.h>
 #include <linux/pl_sensor.h>
 
+#ifdef CONFIG_TOUCHSCREEN_ATMEL_SWEEP2WAKE
+#include <linux/leds-pm8058.h>
+#endif
+
 #define ATMEL_EN_SYSFS
 #define ATMEL_I2C_RETRY_TIMES 10
 
@@ -125,6 +129,60 @@ static void atmel_ts_late_resume(struct early_suspend *h);
 static void restore_normal_threshold(struct atmel_ts_data *ts);
 static void confirm_calibration(struct atmel_ts_data *ts, uint8_t recal, uint8_t reason);
 static void multi_input_report(struct atmel_ts_data *ts);
+
+#ifdef CONFIG_TOUCHSCREEN_ATMEL_SWEEP2WAKE
+/* Sweep to wake values are 
+ * 0 = no sweep2wake
+ * 1 = sweep2wake with no backlight
+ * 2 = sweep2wake with backlight
+ */
+#ifdef CONFIG_TOUCHSCREEN_ATMEL_SWEEP2WAKE_DISABLED
+int s2w_switch = 0;
+int s2w_temp = 0;
+#elif defined(CONFIG_TOUCHSCREEN_ATMEL_SWEEP2WAKE_ENABLED)
+int s2w_switch = 1;
+int s2w_temp = 1;
+#elif defined(CONFIG_TOUCHSCREEN_ATMEL_SWEEP2WAKE_ENABLED_WITH_BACKLIGHT)
+int s2w_switch = 2;
+int s2w_temp = 2;
+#endif
+bool scr_suspended = false, exec_count = true, s2w_switch_changed = false;
+bool scr_on_touch = false, led_exec_count = false, barrier[2] = {false, false};
+static struct input_dev * sweep2wake_pwrdev;
+static struct led_classdev * sweep2wake_leddev;
+static DEFINE_MUTEX(pwrlock);
+
+extern void sweep2wake_setdev(struct input_dev * input_device) {
+	sweep2wake_pwrdev = input_device;
+	return;
+}
+EXPORT_SYMBOL(sweep2wake_setdev);
+
+extern void sweep2wake_setleddev(struct led_classdev * led_dev) {
+	sweep2wake_leddev = led_dev;
+	return;
+}
+EXPORT_SYMBOL(sweep2wake_setleddev);
+
+static void sweep2wake_presspwr(struct work_struct * sweep2wake_presspwr_work) {
+	input_event(sweep2wake_pwrdev, EV_KEY, KEY_POWER, 1);
+	input_event(sweep2wake_pwrdev, EV_SYN, 0, 0);
+	msleep(100);
+	input_event(sweep2wake_pwrdev, EV_KEY, KEY_POWER, 0);
+	input_event(sweep2wake_pwrdev, EV_SYN, 0, 0);
+	msleep(100);
+	mutex_unlock(&pwrlock);
+	return;
+}
+static DECLARE_WORK(sweep2wake_presspwr_work, sweep2wake_presspwr);
+
+void sweep2wake_pwrtrigger(void) {
+	if (mutex_trylock(&pwrlock)) {
+		schedule_work(&sweep2wake_presspwr_work);
+	}
+	return;
+}
+#endif
 
 static int i2c_atmel_read(struct i2c_client *client, uint16_t address, uint8_t *data, uint8_t length)
 {
@@ -632,6 +690,47 @@ static ssize_t atmel_info_show(struct device *dev,
 
 static DEVICE_ATTR(info, S_IRUGO, atmel_info_show, NULL);
 
+#ifdef CONFIG_TOUCHSCREEN_ATMEL_SWEEP2WAKE
+static ssize_t atmel_sweep2wake_show(struct device *dev,
+		struct device_attribute *attr, char *buf)
+{
+	size_t count = 0;
+	
+	if (s2w_switch == s2w_temp )
+		count += sprintf(buf, "%d\n", s2w_switch);
+	else
+		count += sprintf(buf, "%d->%d\n", s2w_switch, s2w_temp);
+
+	return count;
+}
+
+static ssize_t atmel_sweep2wake_dump(struct device *dev,
+		struct device_attribute *attr, const char *buf, size_t count)
+{
+	if (buf[0] >= '0' && buf[0] <= '2' && buf[1] == '\n')
+		if (s2w_switch != buf[0] - '0') {
+			s2w_temp = buf[0] - '0';
+			if (scr_suspended == false)
+				s2w_switch = s2w_temp;
+			else 
+				s2w_switch_changed = true;
+		}
+
+	if (s2w_temp == 0) 
+		printk(KERN_INFO "[sweep2wake]: Disabled.\n");
+	else if (s2w_temp == 1)
+		printk(KERN_INFO "[sweep2wake]: Enabled without Backlight.\n");
+	else if (s2w_temp == 2)
+		printk(KERN_INFO "[sweep2wake]: Enabled with Backlight.\n");
+
+	return count;
+}
+
+static DEVICE_ATTR(sweep2wake, (S_IWUSR|S_IRUGO),
+	atmel_sweep2wake_show, atmel_sweep2wake_dump);
+#endif
+
+
 static struct kobject *android_touch_kobj;
 
 static int atmel_touch_sysfs_init(void)
@@ -643,6 +742,13 @@ static int atmel_touch_sysfs_init(void)
 		ret = -ENOMEM;
 		return ret;
 	}
+#ifdef CONFIG_TOUCHSCREEN_ATMEL_SWEEP2WAKE
+	ret = sysfs_create_file(android_touch_kobj, &dev_attr_sweep2wake.attr);
+	if (ret) {
+		printk(KERN_ERR "%s: sysfs_create_file failed\n", __func__);
+		return ret;
+	}
+#endif
 	ret = sysfs_create_file(android_touch_kobj, &dev_attr_gpio.attr);
 	if (ret) {
 		printk(KERN_ERR "[TP]TOUCH_ERR: create_file gpio failed\n");
@@ -699,6 +805,9 @@ static int atmel_touch_sysfs_init(void)
 
 static void atmel_touch_sysfs_deinit(void)
 {
+#ifdef CONFIG_TOUCHSCREEN_CYPRESS_SWEEP2WAKE
+	sysfs_remove_file(android_touch_kobj, &dev_attr_sweep2wake.attr);
+#endif
 	sysfs_remove_file(android_touch_kobj, &dev_attr_info.attr);
 	sysfs_remove_file(android_touch_kobj, &dev_attr_htc_event.attr);
 	sysfs_remove_file(android_touch_kobj, &dev_attr_unlock.attr);
@@ -1190,6 +1299,9 @@ static void htc_input_report(struct input_dev *idev,
 static void multi_input_report(struct atmel_ts_data *ts)
 {
 	uint8_t loop_i, finger_report = 0;
+#ifdef CONFIG_TOUCHSCREEN_ATMEL_SWEEP2WAKE
+  int prevx = 0, nextx = 0;
+#endif
 
 	for (loop_i = 0; loop_i < ts->finger_support; loop_i++) {
 		if (ts->finger_pressed & BIT(loop_i)) {
@@ -1205,6 +1317,71 @@ static void multi_input_report(struct atmel_ts_data *ts)
 				compatible_input_report(ts->report_both, ts->input_dev, &ts->finger_data[loop_i],
 					1, (ts->finger_count == ++finger_report));
 			}
+#ifdef CONFIG_TOUCHSCREEN_ATMEL_SWEEP2WAKE
+			//left -> right
+			if ((s2w_switch > 0) && (scr_suspended == true) && (ts->finger_count == 1)) {
+				prevx = 0;
+				nextx = 333;
+				if ((barrier[0] == true) ||
+				   ((ts->finger_data[loop_i].x > prevx) &&
+				    (ts->finger_data[loop_i].x < nextx) &&
+				    (ts->finger_data[loop_i].y > 950))) {
+					if ((led_exec_count == true) && (scr_on_touch == false) && (s2w_switch == 2)) {
+						pm8058_drvx_led_brightness_set(sweep2wake_leddev, 255);
+						printk(KERN_INFO "[sweep2wake]: activated button backlight.\n");
+						led_exec_count = false;
+					}
+					prevx = 333;
+					nextx = 667;
+					barrier[0] = true;
+					if ((barrier[1] == true) ||
+					   ((ts->finger_data[loop_i].x > prevx) &&
+					    (ts->finger_data[loop_i].x < nextx) &&
+					    (ts->finger_data[loop_i].y > 950))) {
+						prevx = 667;
+						barrier[1] = true;
+						if ((ts->finger_data[loop_i].x > prevx) &&
+						    (ts->finger_data[loop_i].y > 950)) {
+							if (exec_count) {
+								printk(KERN_INFO "[sweep2wake]: POWER ON.\n");
+								sweep2wake_pwrtrigger();
+								exec_count = false;
+								break;
+							}
+						}
+					}
+				}
+			//right -> left
+			} else if ((s2w_switch > 0) && (scr_suspended == false) && (ts->finger_count == 1)) {
+				scr_on_touch=true;
+				prevx = 1000;
+				nextx = 667;
+				if ((barrier[0] == true) ||
+				   ((ts->finger_data[loop_i].x < prevx) &&
+			    	    (ts->finger_data[loop_i].x > nextx) &&
+				    (ts->finger_data[loop_i].y > 950))) {
+					prevx = 667;
+					nextx = 333;
+					barrier[0] = true;
+					if ((barrier[1] == true) ||
+					   ((ts->finger_data[loop_i].x < prevx) &&
+					    (ts->finger_data[loop_i].x > nextx) &&
+					    (ts->finger_data[loop_i].y > 950))) {
+						prevx = 333;
+						barrier[1] = true;
+						if ((ts->finger_data[loop_i].x < prevx) &&
+						    (ts->finger_data[loop_i].y > 950)) {
+							if (exec_count) {
+								printk(KERN_INFO "[sweep2wake]: POWER OFF.\n");
+								sweep2wake_pwrtrigger();
+								exec_count = false;
+								break;
+							}
+						}
+					}
+				}
+			}
+#endif
 			if (ts->debug_log_level & 0x2)
 				printk(KERN_INFO "Finger %d=> X:%d, Y:%d w:%d, z:%d, F:%d\n",
 					loop_i + 1,
@@ -1290,6 +1467,26 @@ static irqreturn_t atmel_irq_thread(int irq, void *ptr)
 				compatible_input_report(ts->report_both, ts->input_dev, NULL, 0, 1);
 			else
 				htc_input_report(ts->input_dev, NULL, 0, 1);
+
+#ifdef CONFIG_TOUCHSCREEN_ATMEL_SWEEP2WAKE
+		 	/* if finger released, reset count & barriers */
+			if ((((ts->finger_count > 0)?1:0) == 0) && (s2w_switch > 0)) {
+				if ((s2w_switch == 2) &&
+			    	(scr_suspended == true) &&
+			    	(led_exec_count == false) &&
+			    	(scr_on_touch == false) &&
+			    	(exec_count == true)) {
+					pm8058_drvx_led_brightness_set(sweep2wake_leddev, 0);
+					printk(KERN_INFO "[sweep2wake]: deactivated button backlight.\n");
+				}
+				exec_count = true;
+				led_exec_count = true;
+				barrier[0] = false;
+				barrier[1] = false;
+				scr_on_touch = false;
+				printk(KERN_INFO "[sweep2wake]: Finger released, reseting vars.\n");
+			}
+#endif
 
 			if (ts->debug_log_level & 0x2)
 				printk(KERN_INFO "Finger leave\n");
@@ -2353,7 +2550,22 @@ static int atmel_ts_suspend(struct i2c_client *client, pm_message_t mesg)
 
 	printk(KERN_INFO "%s:[TP]enter\n", __func__);
 
-	disable_irq(client->irq);
+#ifdef CONFIG_TOUCHSCREEN_ATMEL_SWEEP2WAKE
+    	scr_suspended = true;
+	if (s2w_switch > 0) {
+		enable_irq_wake(client->irq);
+		printk(KERN_INFO "[sweep2wake]: suspend but keep interupt wake going.\n");
+		if (s2w_switch == 2) {
+			//ensure backlight is turned off
+			pm8058_drvx_led_brightness_set(sweep2wake_leddev, 0);
+			printk(KERN_INFO "[sweep2wake]: deactivated button backlight.\n");
+		}
+ 	} else {
+#endif
+    		disable_irq(client->irq);
+#ifdef CONFIG_TOUCHSCREEN_ATMEL_SWEEP2WAKE
+	}
+#endif
 
 	cancel_delayed_work_sync(&ts->unlock_work);
 	if (ts->pre_data[0] == RECALIB_UNLOCK && ts->psensor_status)
@@ -2371,10 +2583,16 @@ static int atmel_ts_suspend(struct i2c_client *client, pm_message_t mesg)
 			ts->ATCH_EXT, 4);
 	}
 
-	i2c_atmel_write_byte_data(client,
-		get_object_address(ts, GEN_POWERCONFIG_T7) + T7_CFG_IDLEACQINT, 0x0);
-	i2c_atmel_write_byte_data(client,
-		get_object_address(ts, GEN_POWERCONFIG_T7) + T7_CFG_ACTVACQINT, 0x0);
+#ifdef CONFIG_TOUCHSCREEN_ATMEL_SWEEP2WAKE
+  	if (s2w_switch == 0) {
+#endif
+		i2c_atmel_write_byte_data(client,
+			get_object_address(ts, GEN_POWERCONFIG_T7) + T7_CFG_IDLEACQINT, 0x0);
+		i2c_atmel_write_byte_data(client,
+			get_object_address(ts, GEN_POWERCONFIG_T7) + T7_CFG_ACTVACQINT, 0x0);
+#ifdef CONFIG_TOUCHSCREEN_ATMEL_SWEEP2WAKE
+ 	}
+#endif
 
 	printk(KERN_INFO "%s:[TP]done\n", __func__);
 	return 0;
@@ -2385,6 +2603,14 @@ static int atmel_ts_resume(struct i2c_client *client)
 	struct atmel_ts_data *ts = i2c_get_clientdata(client);
 
 	printk(KERN_INFO "%s:[TP]enter\n", __func__);
+
+#ifdef CONFIG_TOUCHSCREEN_ATMEL_SWEEP2WAKE
+    	scr_suspended = false;
+	if (s2w_switch > 0) {
+    		disable_irq_wake(client->irq);
+		printk(KERN_INFO "[sweep2wake]: resume but disable interupt wake.\n");
+  	}
+#endif
 
 	if (ts->id->version >= 0x20 && ts->pre_data[0] == RECALIB_NEED) {
 		if (ts->call_tchthr[0] && ts->psensor_status == 2 && !ts->wlc_status) {
@@ -2403,17 +2629,23 @@ static int atmel_ts_resume(struct i2c_client *client)
 				ts->locking_config[0]);
 		}
 	}
-
-	if (!ts->status && ts->wlc_status && ts->wlc_config[0])
-		i2c_atmel_write(ts->client,
-			get_object_address(ts, GEN_POWERCONFIG_T7),
-			ts->wlc_config,
-			get_object_size(ts, GEN_POWERCONFIG_T7));
-	else
-		i2c_atmel_write(ts->client,
-			get_object_address(ts, GEN_POWERCONFIG_T7),
-			ts->config_setting[ts->status].config_T7,
-			get_object_size(ts, GEN_POWERCONFIG_T7));
+	
+#ifdef CONFIG_TOUCHSCREEN_ATMEL_SWEEP2WAKE
+	if (s2w_switch == 0) {
+#endif
+		if (!ts->status && ts->wlc_status && ts->wlc_config[0])
+			i2c_atmel_write(ts->client,
+				get_object_address(ts, GEN_POWERCONFIG_T7),
+				ts->wlc_config,
+				get_object_size(ts, GEN_POWERCONFIG_T7));
+		else
+			i2c_atmel_write(ts->client,
+				get_object_address(ts, GEN_POWERCONFIG_T7),
+				ts->config_setting[ts->status].config_T7,
+				get_object_size(ts, GEN_POWERCONFIG_T7));
+#ifdef CONFIG_TOUCHSCREEN_ATMEL_SWEEP2WAKE
+  	}
+#endif
 
 	if (ts->id->version == 0x16) {
 		if (ts->config_setting[CONNECTED].config[0] && ts->status &&
@@ -2452,8 +2684,18 @@ static int atmel_ts_resume(struct i2c_client *client)
 				T6_CFG_CALIBRATE, 0x55);
 		}
 	}
-	enable_irq(client->irq);
-
+#ifdef CONFIG_TOUCHSCREEN_ATMEL_SWEEP2WAKE
+  	if (s2w_switch == 0) {
+#endif
+		enable_irq(client->irq);
+#ifdef CONFIG_TOUCHSCREEN_ATMEL_SWEEP2WAKE
+  	}
+	
+	if (s2w_switch_changed == true) {
+		s2w_switch = s2w_temp;
+		s2w_switch_changed = false;
+	}
+#endif
 	printk(KERN_INFO "%s:[TP]done\n", __func__);
 	return 0;
 }

--- a/drivers/leds/leds-pm8058.c
+++ b/drivers/leds/leds-pm8058.c
@@ -27,6 +27,10 @@
 #include <mach/htc_headset_misc.h>
 #endif
 
+#ifdef CONFIG_TOUCHSCREEN_ATMEL_SWEEP2WAKE
+#include <linux/atmel_qt602240.h>
+#endif
+
 #ifdef CONFIG_HTC_HEADSET_MISC
 #define charming_led_enable(enable) headset_indicator_enable(enable)
 #else
@@ -192,7 +196,7 @@ static void pm8058_pwm_led_brightness_set(struct led_classdev *led_cdev,
 	}
 }
 
-static void pm8058_drvx_led_brightness_set(struct led_classdev *led_cdev,
+extern void pm8058_drvx_led_brightness_set(struct led_classdev *led_cdev,
 					   enum led_brightness brightness)
 {
 	struct pm8058_led_data *ldata;
@@ -734,6 +738,13 @@ static int pm8058_led_probe(struct platform_device *pdev)
 			goto err_register_attr_pwm_coefficient;
 		}
 	}
+
+#ifdef CONFIG_TOUCHSCREEN_ATMEL_SWEEP2WAKE
+	if (!strcmp(pdata->led_config[2].name, "button-backlight")) {
+		sweep2wake_setleddev(&ldata[2].ldev);
+		printk(KERN_INFO "[sweep2wake]: set led device %s, bank %d\n", pdata->led_config[2].name, ldata[2].bank);
+	}
+#endif
 
 	return 0;
 

--- a/include/linux/atmel_qt602240.h
+++ b/include/linux/atmel_qt602240.h
@@ -2,6 +2,10 @@
 #define _LINUX_ATMEL_H
 
 #include <linux/bitops.h>
+#ifdef CONFIG_TOUCHSCREEN_ATMEL_SWEEP2WAKE
+#include <linux/input.h>
+#include <linux/leds-pm8058.h>
+#endif
 
 #define ATMEL_QT602240_NAME "atmel_qt602240"
 #define ATMEL_MXT224E_NAME "atmel_mxt224e"
@@ -522,6 +526,11 @@ struct atmel_config_data {
 	int8_t *config_T55;
 	int8_t *config_T58;
 };
+
+#ifdef CONFIG_TOUCHSCREEN_ATMEL_SWEEP2WAKE
+extern void sweep2wake_setdev(struct input_dev * input_device);
+extern void sweep2wake_setleddev(struct led_classdev * led_dev);
+#endif
 
 #endif
 

--- a/include/linux/leds-pm8058.h
+++ b/include/linux/leds-pm8058.h
@@ -88,4 +88,8 @@ struct pm8058_led_data {
 	int out_current;
 };
 void button_backlight_flash (int brightness_key);
+
+extern void pm8058_drvx_led_brightness_set(struct led_classdev *led_cdev,
+		enum led_brightness brightness);
+
 #endif /* _LINUX_LEDS_PM8058_H */


### PR DESCRIPTION
Hi sir.

Here you go.

config should have the following because default is set to not build into kernel.
# 

CONFIG_TOUCHSCREEN_ATMEL_SWEEP2WAKE=y
CONFIG_TOUCHSCREEN_ATMEL_SWEEP2WAKE_DISABLED=y or
CONFIG_TOUCHSCREEN_ATMEL_SWEEP2WAKE_ENABLED=y or
# CONFIG_TOUCHSCREEN_ATMEL_SWEEP2WAKE_ENABLED_WITH_BACKLIGHT=y

cheers
cjoliver
